### PR TITLE
Update polyfaq.tex

### DIFF
--- a/polyfaq.tex
+++ b/polyfaq.tex
@@ -16,9 +16,6 @@
 %\usepackage[dvips,draft]{graphicx}   % unix environment
 \usepackage[dvips,final]{graphicx}   % unix environment
 
-\usepackage{amsmath}
-\usepackage{hyperref}
-
 \DeclareGraphicsExtensions{.jpg,.eps}
 \DeclareGraphicsRule{.jpg}{eps}{.jpg.bb}{`jpeg2ps -h -r 600 #1}
 \graphicspath{{Figures/}{eps/}}


### PR DESCRIPTION
The two lines deleted seem to have created the wrong wrapping of the table of contents
with latex.  (while xelatex does the correct wrapping without these changes.)

Anyway, the package amsmath is declared earlier and thus a repetition.  
The second package is not used at all.